### PR TITLE
Add source information and license declaration for amoro-theme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,14 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Iceberg.
+
+* amoro-theme is based on iceberg-theme
+
+Copyright: 2011-2019 The Apache Software Foundation
+Home page: https://iceberg.apache.org/
+License: http://www.apache.org/licenses/LICENSE-2.0

--- a/amoro-theme/README.md
+++ b/amoro-theme/README.md
@@ -1,6 +1,7 @@
-# Iceberg Theme
+# Amoro Theme
 
-The Iceberg theme is a theme for use with [Hugo](https://gohugo.io/).
+The Amoro theme is a theme for use with [Hugo](https://gohugo.io/).
+The Amoro theme is copied from [Apache Iceberg Project](https://github.com/apache/iceberg-docs/tree/main/iceberg-theme) and modifications were made as needed.
 
 ## Hint Boxes
 


### PR DESCRIPTION
amoro-theme is copied from Apache Iceberg project, we should add the source information and license declaration for it.